### PR TITLE
Process Weekly + UserStats

### DIFF
--- a/Backend/Controllers/ScoringController.cs
+++ b/Backend/Controllers/ScoringController.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MokSportsApp.Data;    // AppDbContext + Game entity
 using MokSportsApp.DTO;     // CompletedGameDTO
+using MokSportsApp.Services.Implementations;
+using MokSportsApp.Models;
+
 
 namespace MokSportsApp.Controllers
 {
@@ -12,10 +15,11 @@ namespace MokSportsApp.Controllers
     public class ScoringController : ControllerBase
     {
         private readonly AppDbContext _context;
-
-        public ScoringController(AppDbContext context)
+        private readonly ScoringService _scoringService;
+        public ScoringController(AppDbContext context, ScoringService scoringService)
         {
             _context = context;
+            _scoringService = scoringService;
         }
 
         /// <summary>
@@ -84,6 +88,94 @@ namespace MokSportsApp.Controllers
                     new { message = "An error occurred while retrieving user stats." });
             }
         }
+
+        [HttpPost("processweeklyscores/{FranchiseId:int}/{WeekId:int}")]
+        [Consumes("application/json")]
+        public IActionResult ProcessWeeklyScores(
+        [FromRoute] int FranchiseId,
+        [FromRoute] int WeekId,
+        [FromBody] ProcessWeeklyScoresRequestDTO req)
+        {
+            if (FranchiseId <= 0 || WeekId <= 0)
+                return BadRequest(new { message = "FranchiseId and WeekId must be > 0." });
+
+            var stats = _context.UserStats
+                .SingleOrDefault(u => u.FranchiseId == FranchiseId && u.WeekId == WeekId);
+
+            if (stats == null)
+                return NotFound(new { message = $"User stats not found for FranchiseId={FranchiseId}, WeekId={WeekId}" });
+
+            var weekResult = new WeekResult
+            {
+                Team1Result = req.Team1Result,
+                Team2Result = req.Team2Result,
+                Team3Result = req.Team3Result,
+                BlowoutOpponent = req.BlowoutOpponent,
+                ShutoutOpponent = req.ShutoutOpponent,
+                HighestScorer = req.HighestScorer,
+                LowestScorer = req.LowestScorer,
+                Lok = req.Lok,
+                Load = req.Load
+            };
+
+            var teamNames = new[] { "Team 1", "Team 2", "Team 3" }.ToList();
+            int weekScore = _scoringService.CalculateScore(weekResult, teamNames);
+
+            stats.WeekPoints = weekScore;
+            stats.SeasonPoints = stats.SeasonPoints + weekScore;
+
+            _context.SaveChanges();
+
+            return Ok(new ProcessWeeklyScoresResponseDTO
+            {
+                FranchiseId = stats.FranchiseId,
+                WeekId = stats.WeekId,
+                WeekPoints = weekScore,
+                SeasonPoints = stats.SeasonPoints
+            });
+        }
+
+        [HttpGet("FranchiseTeams+Points/{FranchiseId:int}")]
+        public IActionResult GetFranchiseTeamsAndPoints(
+            [FromRoute] int FranchiseId
+        )
+        {
+            if (FranchiseId <= 0)
+                return BadRequest(new { message = "FranchiseId must be > 0." });
+
+            try
+            {
+                var f = _context.Franchises
+                    .SingleOrDefault(x => x.FranchiseId == FranchiseId);
+
+                if (f == null)
+                    return NotFound(new { message = $"Franchise with Id={FranchiseId} not found." });
+
+                var teamIds = new[]
+                {
+                    f.Team1Id ?? 0,
+                    f.Team2Id ?? 0,
+                    f.Team3Id ?? 0,
+                    f.Team4Id ?? 0,
+                    f.Team5Id ?? 0
+                };
+
+                var seasonPoints = f.SeasonPoints ?? 0;
+
+                return Ok(new
+                {
+                    franchiseId = f.FranchiseId,
+                    teamIds,
+                    seasonPoints
+                });
+            }
+            catch
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    new { message = "An error occurred while retrieving franchise teams and points." });
+            }
+        }
+           
     }
 }
 

--- a/Backend/DTO/ProcessWeeklyScoresRequestDTO.cs
+++ b/Backend/DTO/ProcessWeeklyScoresRequestDTO.cs
@@ -1,0 +1,14 @@
+public class ProcessWeeklyScoresRequestDTO
+{
+    public int FranchiseId { get; set; }
+    public int WeekId       { get; set; }
+    public string Team1Result { get; set; }
+    public string Team2Result { get; set; }
+    public string Team3Result { get; set; }
+    public bool BlowoutOpponent { get; set; }
+    public bool ShutoutOpponent { get; set; }
+    public bool HighestScorer   { get; set; }
+    public bool LowestScorer    { get; set; }
+    public string Lok  { get; set; }
+    public string Load { get; set; }
+}

--- a/Backend/DTO/ProcessWeeklyScoresResponseDTO.cs
+++ b/Backend/DTO/ProcessWeeklyScoresResponseDTO.cs
@@ -1,0 +1,7 @@
+public class ProcessWeeklyScoresResponseDTO
+{
+    public int FranchiseId   { get; set; }
+    public int WeekId        { get; set; }
+    public int WeekPoints { get; set; }
+    public double SeasonPoints { get; set; }
+}

--- a/Backend/Models/WeekResult.cs
+++ b/Backend/Models/WeekResult.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace MokSportsApp.Models
+{
+    public class WeekResult
+    {
+        public string Team1Result { get; set; }
+        public string Team2Result { get; set; }
+        public string Team3Result { get; set; }
+        public bool BlowoutOpponent { get; set; }
+        public bool ShutoutOpponent { get; set; }
+        public bool HighestScorer { get; set; }
+        public bool LowestScorer { get; set; }
+        public string Lok { get; set; }
+        public string Load { get; set; }
+    }
+}

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -51,6 +51,7 @@ builder.Services.AddScoped<IDraftService, DraftService>();
 builder.Services.AddScoped<ITradeService, TradeService>();
 builder.Services.AddScoped<ISeasonService, SeasonService>();
 
+builder.Services.AddScoped<ScoringService>();
 
 
 // Configure JSON serialization to handle circular references

--- a/Backend/Services/Implementations/ScoringService.cs
+++ b/Backend/Services/Implementations/ScoringService.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using MokSportsApp.Data.Repositories.Interfaces;
+using MokSportsApp.DTO;
+using MokSportsApp.Models;
+using MokSportsApp.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MokSportsApp.Services.Implementations
+{
+    public class ScoringService
+    {
+        public int CalculateScore(WeekResult weekResult, List<string> teamNames)
+        {
+            int score = 0;
+
+            // Team results
+            score += CalculateTeamScore(weekResult.Team1Result, teamNames[0], weekResult);
+            score += CalculateTeamScore(weekResult.Team2Result, teamNames[1], weekResult);
+            score += CalculateTeamScore(weekResult.Team3Result, teamNames[2], weekResult);
+
+            // Blowout opponent
+            if (weekResult.BlowoutOpponent) score++;
+
+            // Shutout opponent
+            if (weekResult.ShutoutOpponent) score++;
+
+            // Highest scorer
+            if (weekResult.HighestScorer) score++;
+
+            // Lowest scorer
+            if (weekResult.LowestScorer) score--;
+
+            return score;
+        }
+
+        private int CalculateTeamScore(string result, string teamName, WeekResult weekResult)
+        {
+            int teamScore = 0;
+
+            if (result == "W") teamScore++;
+            if (result == "L") teamScore--;
+            if (result == "T") teamScore += 0;
+
+            if (weekResult.Lok == "YW" && teamName == GetLokTeamName(weekResult)) teamScore++;
+            if (weekResult.Lok == "YL" && teamName == GetLokTeamName(weekResult)) teamScore--;
+            if (weekResult.Load == "YW" && teamName == GetLoadTeamName(weekResult)) teamScore += 2;
+            if (weekResult.Load == "YL" && teamName == GetLoadTeamName(weekResult)) teamScore--;
+
+            return teamScore;
+        }
+
+        private string GetLokTeamName(WeekResult weekResult)
+        {
+            return weekResult.Lok == "YW" || weekResult.Lok == "YL" ? "Lok Team Name" : string.Empty;
+        }
+
+        private string GetLoadTeamName(WeekResult weekResult)
+        {
+            return weekResult.Load == "YW" || weekResult.Load == "YL" ? "Load Team Name" : string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
Added Logic/Prototype for process weekly. Edge cases work but we need an actual table with data to test on. Userstats was implemented as "FranchiseTeams+Points", this just gives a franchises id and corresponding teams with season points as there is no existing breakdown in the current database so we might have to update that if needed for MVP.